### PR TITLE
fixed syntax error [: missing `]'

### DIFF
--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -88,7 +88,7 @@ fn_stop_graceful_goldsource(){
 
 # Attempts graceful of 7 Days To Die using telnet.
 fn_stop_telnet_sdtd(){
-	if [ -z "${telnetpass}"]; then
+	if [ -z "${telnetpass}" ]; then
 		telnetpass="NOTSET"
 	fi
 	sdtd_telnet_shutdown=$( expect -c '


### PR DESCRIPTION
fixed [ .... ] Stopping sdtdserver: Graceful: telnet: 127.0.0.1/home/sdtdserver/lgsm/functions/command_stop.sh: line 91: [: missing `]'